### PR TITLE
feat: checkout specific model SHA and annotate

### DIFF
--- a/models/Dockerfile
+++ b/models/Dockerfile
@@ -1,8 +1,13 @@
 FROM debian:12-slim as downloader
 
 # Specify the huggingface model such as microsoft/resnet-50
-# `depot build --build-arg="MODEL=microsoft/resnet-50" --output=type=image,name=depot.ai/microsoft/resnet-50:latest,push=true,compression=estargz,oci-mediatypes=true .`
+# depot build
+# --build-arg="MODEL=microsoft/resnet-50"
+# --build-arg="SHA=4067a2728b9c93fbd67b9d5a30b03495ac74a46e
+# --output=type=image,name=depot.ai/microsoft/resnet-50:latest,push=true,compression=estargz,oci-mediatypes=true
+# --provenance=false .
 ARG MODEL
+ARG SHA
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends git-lfs=3.3.0-1+b5 ca-certificates \
@@ -11,7 +16,11 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 
-RUN git clone https://huggingface.co/${MODEL} /model && rm -rf /model/.git
+RUN git clone https://huggingface.co/${MODEL} /model && cd /model && git checkout ${SHA} && rm -rf /model/.git
 
 FROM scratch as model
+
+LABEL org.opencontainers.image.source="https://huggingface.co/$MODEL"
+LABEL org.opencontainers.image.revision="$SHA"
+
 COPY --from=downloader /model /

--- a/models/build.ts
+++ b/models/build.ts
@@ -1,4 +1,3 @@
-import {$} from 'execa'
 import * as fsp from 'node:fs/promises'
 import {parse} from 'yaml'
 
@@ -14,14 +13,14 @@ async function main() {
       throw new Error('Usage: build.ts <modelList>')
     })()
 
-  const modelListFile = args[1] || 'models/models.yaml'
+  const modelListFile = args[1] || 'models.yaml'
   const octets = await fsp.readFile(modelListFile, 'utf8')
   const parsed: {models: Model[]} = parse(octets)
 
   for (const model of parsed.models) {
     await $({
       stdio: 'inherit',
-    })`depot build --build-arg=MODEL=${model.name} --output=type=image,name=us-docker.pkg.dev/depot-gcp/depot-ai/${model.name}:latest,push=true,compression=estargz,oci-mediatypes=true --provenance false --progress plain -f models/Dockerfile .`
+    })`depot build --platform linux/amd64,linux/arm64 --build-arg=MODEL=${model.name} --build-arg=SHA=${model.sha} --output=type=image,name=us-docker.pkg.dev/depot-gcp/depot-ai/${model.name}:latest,push=true,compression=estargz,oci-mediatypes=true,annotation.org.opencontainers.image.revision=${model.sha},annotation.org.opencontainers.image.source=https://huggingface.co/${model.name},annotation-index.org.opencontainers.image.revision=${model.sha},annotation-index.org.opencontainers.image.source=https://huggingface.co/${model.name},annotation-manifest-descriptor.org.opencontainers.image.revision=${model.sha},annotation-manifest-descriptor.org.opencontainers.image.source=https://huggingface.co/${model.name} --provenance false --progress plain -f Dockerfile .`
   }
   console.log('Done!')
 }

--- a/models/top.ts
+++ b/models/top.ts
@@ -23,10 +23,10 @@ async function main() {
       throw new Error('Usage: top.ts <topN> [outputFile]')
     })()
   if (args.length === 1) {
-    args.push('models/models.yaml')
+    args.push('models.yaml')
   }
   const topN = parseInt(args[0] || '100')
-  const outputFile = args[1] || 'models/models.yaml'
+  const outputFile = args[1] || 'models.yaml'
 
   const models = {models: await getTopHuggingFaceModels(topN)}
   const yaml = stringify(models)


### PR DESCRIPTION
Instead of HEAD we now checkout a specific SHA.
Additionally, the SHA and git repo are recorded
as annotations and image labels.