### PR TITLE
feat: add thebloke/llama-2-7b-chat-ggml

### DIFF
--- a/models/models.yaml
+++ b/models/models.yaml
@@ -302,3 +302,6 @@ models:
   - name: meta-llama/llama-2-70b-chat-hf
     sha: 9fd3d5efc9c9d5cae982ecb27862b9d02d19a07e
     tagAs: latest
+  - name: thebloke/llama-2-7b-chat-ggml
+    sha: b616819cd4777514e3a2d9b8be69824aca8f5daf
+    tagAs: latest


### PR DESCRIPTION
GGML is the model format for llama.cpp.
This HF repo converted llama2's 7B chat.