### PR TITLE
Pull LFS files with `git lfs pull` to reduce memory usage

### DIFF
--- a/models/Dockerfile
+++ b/models/Dockerfile
@@ -19,8 +19,9 @@ RUN apt-get update \
 RUN --mount=type=ssh \
   mkdir -p ~/.ssh && \
   ssh-keyscan hf.co >> ~/.ssh/known_hosts && \
-  git clone git@hf.co:${MODEL} /model && \
+  env GIT_LFS_SKIP_SMUDGE=1 git clone git@hf.co:${MODEL} /model && \
   cd /model && \
+  git lfs pull && \
   git reset --hard ${SHA} && \
   rm -rf .git .gitattributes && \
   find . -newermt "@${SOURCE_DATE_EPOCH}" -writable -xdev | xargs touch --date="@${SOURCE_DATE_EPOCH}" --no-dereference


### PR DESCRIPTION
`git clone` uses a _lot_ of memory and potentially has issues when the LFS objects are larger than RAM on the host. This PR changes the clone to first clone without the LFS files and then use `git lfs pull` to acquire them as that does not load the individual files into RAM.